### PR TITLE
Revert "Use XmlSerializer over BinaryFormatter"

### DIFF
--- a/Quaver.API/Helpers/Objects.cs
+++ b/Quaver.API/Helpers/Objects.cs
@@ -1,5 +1,5 @@
 ﻿using System.IO;
-using System.Xml.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
 
 namespace Quaver.API.Helpers
 {
@@ -15,7 +15,7 @@ namespace Quaver.API.Helpers
         {
             using (var ms = new MemoryStream())
             {
-                var formatter = new XmlSerializer(typeof(T));
+                var formatter = new BinaryFormatter();
                 formatter.Serialize(ms, obj);
                 ms.Position = 0;
 


### PR DESCRIPTION
Reverts Quaver/Quaver.API#153
XmlSerializer causes some issues.