### PR TITLE
Fix 'feat.' regex matching

### DIFF
--- a/Quaver.API/Maps/AutoMod/AutoMod.cs
+++ b/Quaver.API/Maps/AutoMod/AutoMod.cs
@@ -346,8 +346,8 @@ namespace Quaver.API.Maps.AutoMod
             if (!fieldValue.Contains("vs.") && vsMatch.Success)
                 Issues.Add(new AutoModIssueNonStandardizedMetadata(fieldName, vsMatch.Groups[1].Value, "vs."));
 
-            var featMatch = new Regex(@"\b(ft\.?|feat\.?)", RegexOptions.IgnoreCase).Match(fieldValue);
-            if (!fieldValue.Contains("feat.") && featMatch.Success)
+            var featMatch = new Regex(@"\b(ft[\s|.]|feat\s)", RegexOptions.IgnoreCase).Match(fieldValue);
+            if (featMatch.Success)
                 Issues.Add(new AutoModIssueNonStandardizedMetadata(fieldName, featMatch.Groups[1].Value, "feat."));
         }
 


### PR DESCRIPTION
Minor change to resolve issue #184, and was something I came across recently as well

Ensures that AutoMod will not flag "invalid" `feat.` sequences that appear within words/names.
Will also now flag multiple counts of violations, even if a field contains a valid `feat.`

e.g. the following are flagged,
```
ft. me
feat me
ft me
feat. this, feat you, ft.me   // this was previously considered valid
```
but not,
```
feat. me
feat.you
ftlframe
FTN-Remix
```
