### PR TITLE
Fix mines not handled properly in autoplay

### DIFF
--- a/Quaver.API/Replays/Replay.cs
+++ b/Quaver.API/Replays/Replay.cs
@@ -378,6 +378,10 @@ namespace Quaver.API.Replays
                 replay.Frames.Add(new ReplayFrame(item.Key, state));
             }
 
+            // Add ending frame w/ no press state. (+10000 just to be on the safe side.)
+            // This ensures that mines are handled at the end of the map.
+            replay.Frames.Add(new ReplayFrame(map.Length + 10000, 0));
+
             return replay;
         }
 


### PR DESCRIPTION
This was due to that when generating the autoplay replay, the last frame might not be after the mine, which would've been the case for human played replays (See ReplayCapturer.Capture, where it adds additional frames if judgement count doesn't match). So, an additional frame is added at the end + 10000ms to force handling all mines.