### PR TITLE
Do not count mine clears as a judgement

### DIFF
--- a/Quaver.API/Maps/Processors/Scoring/ScoreProcessor.cs
+++ b/Quaver.API/Maps/Processors/Scoring/ScoreProcessor.cs
@@ -114,6 +114,11 @@ namespace Quaver.API.Maps.Processors.Scoring
         };
 
         /// <summary>
+        ///     The amount of mine hits the user got.
+        /// </summary>
+        public int CountMineHit { get; set; } = 0;
+
+        /// <summary>
         ///     The judgement windows defined per mode.
         /// </summary>
         public abstract SortedDictionary<Judgement, float> JudgementWindow { get; set; }
@@ -215,6 +220,7 @@ namespace Quaver.API.Maps.Processors.Scoring
             CurrentJudgements[Judgement.Good] = replay.CountGood;
             CurrentJudgements[Judgement.Okay] = replay.CountOkay;
             CurrentJudgements[Judgement.Miss] = replay.CountMiss;
+            CountMineHit = replay.CountMineHit;
 
             InitializeJudgementWindows(windows);
             InitializeMods();

--- a/Quaver.API/Maps/Processors/Scoring/ScoreProcessorKeys.cs
+++ b/Quaver.API/Maps/Processors/Scoring/ScoreProcessorKeys.cs
@@ -34,6 +34,11 @@ namespace Quaver.API.Maps.Processors.Scoring
         private int TotalJudgements { get; }
 
         /// <summary>
+        ///     Total number of mines in the map.
+        /// </summary>
+        private int MineCount { get; }
+
+        /// <summary>
         ///     See: ScoreProcessorKeys.CalculateSummedScore();
         /// </summary>
         private int SummedScore { get; }
@@ -143,6 +148,7 @@ namespace Quaver.API.Maps.Processors.Scoring
         public ScoreProcessorKeys(Qua map, ModIdentifier mods, JudgementWindows windows = null) : base(map, mods, windows)
         {
             TotalJudgements = GetTotalJudgementCount();
+            MineCount = map.MineCount;
             SummedScore = CalculateSummedScore();
             InitializeHealthWeighting();
         }
@@ -157,6 +163,7 @@ namespace Quaver.API.Maps.Processors.Scoring
         public ScoreProcessorKeys(Qua map, ModIdentifier mods, ScoreProcessorMultiplayer multiplayer, JudgementWindows windows = null) : base(map, mods, multiplayer, windows)
         {
             TotalJudgements = GetTotalJudgementCount();
+            MineCount = map.MineCount;
             SummedScore = CalculateSummedScore();
             InitializeHealthWeighting();
         }
@@ -402,9 +409,14 @@ namespace Quaver.API.Maps.Processors.Scoring
             // Multiplier doesn't increase after this amount.
             var maxMultiplierCount = MultiplierMaxIndex * MultiplierCountToIncreaseIndex;
 
+            // The total number of judgements for a maximum score would be excluding the number of mines.
+            // This is because both a mine hit (a miss) and a mine clear (nothing) will gain 0 point,
+            // but a mine hit resets combo, reducing score.
+            var totalJudgements = TotalJudgements - MineCount;
+
             // Calculate score for notes below max multiplier combo
             // Note: This block could be a constant for songs that have max combo that exceeds the max multiplier count, but that will mean we will have to manually change the constant everytime we update any single other constant.
-            for (var i = 1; i <= TotalJudgements && i < maxMultiplierCount; i++)
+            for (var i = 1; i <= totalJudgements && i < maxMultiplierCount; i++)
                 summedScore += JudgementScoreWeighting[Judgement.Marv] + MultiplierCountToIncreaseIndex * (int) Math.Floor((float)i / MultiplierCountToIncreaseIndex);
 
             // Calculate score for notes once max multiplier combo is reached

--- a/Quaver.API/Maps/Processors/Scoring/ScoreProcessorKeys.cs
+++ b/Quaver.API/Maps/Processors/Scoring/ScoreProcessorKeys.cs
@@ -255,6 +255,8 @@ namespace Quaver.API.Maps.Processors.Scoring
             // Update Judgement count
             CurrentJudgements[judgement]++;
 
+            if (isMine) CountMineHit++;
+
             // Calculate and set the new accuracy.
             Accuracy = CalculateAccuracy();
 

--- a/Quaver.API/Replays/Replay.cs
+++ b/Quaver.API/Replays/Replay.cs
@@ -287,12 +287,7 @@ namespace Quaver.API.Replays
         {
             var frames = FramesToString();
 
-            // TOOD: This should be removed when everyone is running the new redesign client
-            // This will manually downgrade the replay version if the user isn't using new modifiers to keep
-            // compatibility between old and new clients.
-            // 0.0.1 used to write the modifiers as a 32-bit integer, but because of the amount of new mods, they need
-            // to be written as 64-bit.
-            ReplayVersion = Mods < ModIdentifier.Speed105X ? "0.0.1" : CurrentVersion;
+            ReplayVersion = CurrentVersionString;
 
             using (var replayDataStream = new MemoryStream(Encoding.ASCII.GetBytes(frames)))
             using (var bw = new BinaryWriter(File.Open(path, FileMode.Create)))

--- a/Quaver.API/Replays/Replay.cs
+++ b/Quaver.API/Replays/Replay.cs
@@ -22,11 +22,16 @@ namespace Quaver.API.Replays
     public class Replay
     {
         /// <summary>
-        ///     The version of the replay.
+        ///     The version string of the replay.
         /// </summary>
-        public static string CurrentVersion { get; } = "0.0.3";
+        public static string CurrentVersionString => CurrentVersion.ToString();
 
         public static readonly Version VersionMineHit = new Version(0, 0, 3);
+
+        /// <summary>
+        ///     The version of the replay.
+        /// </summary>
+        public static Version CurrentVersion => VersionMineHit;
 
         /// <summary>
         ///     The game mode this replay is for.
@@ -169,6 +174,16 @@ namespace Quaver.API.Replays
                 {
                     // Version None (Original data)
                     ReplayVersion = br.ReadString();
+
+                    // Reject future versions
+                    if (ReplayVersion != "None")
+                    {
+                        if (!Version.TryParse(ReplayVersion, out var version) || version > CurrentVersion)
+                        {
+                            throw new ArgumentOutOfRangeException($"Replay version {version} is newer than current version {CurrentVersion}");
+                        }
+                    }
+
                     MapMd5 = br.ReadString();
                     Md5 = br.ReadString();
                     PlayerName = br.ReadString();
@@ -501,7 +516,7 @@ namespace Quaver.API.Replays
         /// <returns></returns>
         public string GetMd5(string frames)
         {
-            if (Version.TryParse(CurrentVersion, out var ver) && ver >= VersionMineHit)
+            if (Version.TryParse(CurrentVersionString, out var ver) && ver >= VersionMineHit)
             {
                 return CryptoHelper.StringToMd5($"{ReplayVersion}-{TimePlayed}-{MapMd5}-{PlayerName}-{(int)Mode}-" +
                                                 $"{(int)Mods}-{Score}-{Accuracy}-{MaxCombo}-{CountMarv}-{CountPerf}-" +

--- a/Quaver.API/Replays/Replay.cs
+++ b/Quaver.API/Replays/Replay.cs
@@ -24,7 +24,9 @@ namespace Quaver.API.Replays
         /// <summary>
         ///     The version of the replay.
         /// </summary>
-        public static string CurrentVersion { get; } = "0.0.2";
+        public static string CurrentVersion { get; } = "0.0.3";
+
+        public static readonly Version VersionMineHit = new Version(0, 0, 3);
 
         /// <summary>
         ///     The game mode this replay is for.
@@ -115,6 +117,11 @@ namespace Quaver.API.Replays
         ///     Amount of miss judgements.
         /// </summary>
         public int CountMiss { get; set; }
+        
+        /// <summary>
+        ///     Amount of mine hits.
+        /// </summary>
+        public int CountMineHit { get; set; }
 
         /// <summary>
         ///     The amount of times paused in the play.
@@ -211,6 +218,12 @@ namespace Quaver.API.Replays
                     CountGood = br.ReadInt32();
                     CountOkay = br.ReadInt32();
                     CountMiss = br.ReadInt32();
+
+                    if (Version.TryParse(ReplayVersion, out var ver) && ver >= VersionMineHit)
+                    {
+                        CountMineHit = br.ReadInt32();
+                    }
+                    
                     PauseCount = br.ReadInt32();
 
                     // Versions beyond None
@@ -291,6 +304,12 @@ namespace Quaver.API.Replays
                 bw.Write(CountGood);
                 bw.Write(CountOkay);
                 bw.Write(CountMiss);
+
+                if (Version.TryParse(ReplayVersion, out var ver) && ver >= VersionMineHit)
+                {
+                    bw.Write(CountMineHit);
+                }
+
                 bw.Write(PauseCount);
                 bw.Write(RandomizeModifierSeed);
 
@@ -318,6 +337,7 @@ namespace Quaver.API.Replays
             CountGood = processor.CurrentJudgements[Judgement.Good];
             CountOkay = processor.CurrentJudgements[Judgement.Okay];
             CountMiss = processor.CurrentJudgements[Judgement.Miss];
+            CountMineHit = processor.CountMineHit;
         }
 
         /// <summary>
@@ -481,6 +501,12 @@ namespace Quaver.API.Replays
         /// <returns></returns>
         public string GetMd5(string frames)
         {
+            if (Version.TryParse(CurrentVersion, out var ver) && ver >= VersionMineHit)
+            {
+                return CryptoHelper.StringToMd5($"{ReplayVersion}-{TimePlayed}-{MapMd5}-{PlayerName}-{(int)Mode}-" +
+                                                $"{(int)Mods}-{Score}-{Accuracy}-{MaxCombo}-{CountMarv}-{CountPerf}-" +
+                                                $"{CountGreat}-{CountGood}-{CountOkay}-{CountMiss}-{CountMineHit}-{PauseCount}-{RandomizeModifierSeed}-{frames}");
+            }
             return CryptoHelper.StringToMd5($"{ReplayVersion}-{TimePlayed}-{MapMd5}-{PlayerName}-{(int)Mode}-" +
                                             $"{(int)Mods}-{Score}-{Accuracy}-{MaxCombo}-{CountMarv}-{CountPerf}-" +
                                             $"{CountGreat}-{CountGood}-{CountOkay}-{CountMiss}-{PauseCount}-{RandomizeModifierSeed}-{frames}");

--- a/Quaver.API/Replays/Virtual/VirtualReplayPlayer.cs
+++ b/Quaver.API/Replays/Virtual/VirtualReplayPlayer.cs
@@ -446,20 +446,13 @@ namespace Quaver.API.Replays.Virtual
                 }
             }
             // Handle missed mines.
-            // 'Missed' as in the mines were not triggered, meaning a marvelous judgement should be given.
+            // 'Missed' as in the mines were not triggered. This will not reward the player by design.
             foreach (var hitObject in ActiveMines)
             {
                 var endTime = hitObject.IsLongNote ? hitObject.EndTime : hitObject.StartTime;
                 if (Time > endTime + ScoreProcessor.JudgementWindow[Judgement.Marv])
                 {
-                    // Create a new HitStat to add to the ScoreProcessor.
-                    // Award a Marvelous for successfully avoiding the mine.
-                    var stat = new HitStat(HitStatType.Hit, KeyPressType.None, hitObject, hitObject.StartTime, Judgement.Marv, 0,
-                        ScoreProcessor.Accuracy, ScoreProcessor.Health);
-
-                    ScoreProcessor.CalculateScore(stat);
-
-                    ScoreProcessor.Stats.Add(stat);
+                    // Simply remove the mine. We do not count a cleared mine into statistics.
                     ActiveMinesToRemove.Add(hitObject);
                 }
                 else if (Time < hitObject.StartTime - ScoreProcessor.JudgementWindow[Judgement.Marv])


### PR DESCRIPTION
Requires https://github.com/Quaver/Quaver.Server.Client/pull/36

This PR aims to reduce situation where a player would gain accuracy due to excessive number of mines. This is achieved by making a mine clear (the player not pressing the mines) not count towards a marvelous. A mine hit will still count as a miss.

Update score calculation such that the maximum score will be the maximum number of judgements minus the number of mines.

The following figure will show the updates to score calculation. Might need further investigation on whether this is potentially breakable.

![figure 1: all marvelous with mine hit](https://cdn.discordapp.com/attachments/570610717720313875/1479296252905521243/image.png?ex=69ab857e&is=69aa33fe&hm=ea76398f3267501b6dfbbf84f22a4c88fec5590cb8309ba79ff159303da1a44a&)

![figure 2: all marvelous with mine clear](https://cdn.discordapp.com/attachments/570610717720313875/1479296253396385792/image.png?ex=69ab857e&is=69aa33fe&hm=1e0786a4ce5547aa67e6f97e61bfe3dada61d93e00bb91543adff624860ee93a&)

The above scores are set on a map with 12 normal notes, followed by a mine, and followed by a normal note.

When the mine is hit, the player gets a miss, breaking the combo and thus does not get the maximum score.

When the mine is cleared, the player will get no judgement, but full score may be given.


*PS* funny thing I got during development ![funny](https://cdn.discordapp.com/attachments/570610717720313875/1479292989112057907/image.png?ex=69ab8274&is=69aa30f4&hm=70286a9136c73e82461e8bda08e393d3ab5b694696a71f88535974756b8258de&)