### PR TITLE
Update Quaver.Tools usage and fix replay incompatibility

### DIFF
--- a/Quaver.API/Replays/Replay.cs
+++ b/Quaver.API/Replays/Replay.cs
@@ -299,12 +299,7 @@ namespace Quaver.API.Replays
                 bw.Write(DateTime.Now.ToString(CultureInfo.InvariantCulture));
                 bw.Write(TimePlayed);
                 bw.Write((int)Mode);
-                // This check is to keep compatibility with older clients.
-                // We only want to write a 64-bit integer for replays with newer mods activated
-                if (ReplayVersion == "0.0.1" || Mods < ModIdentifier.Speed105X)
-                    bw.Write((int)Mods);
-                else
-                    bw.Write((long)Mods);
+                bw.Write((long)Mods);
                 bw.Write(Score);
                 bw.Write(Accuracy);
                 bw.Write(MaxCombo);
@@ -511,7 +506,7 @@ namespace Quaver.API.Replays
         /// <returns></returns>
         public string GetMd5(string frames)
         {
-            if (Version.TryParse(CurrentVersionString, out var ver) && ver >= VersionMineHit)
+            if (Version.TryParse(ReplayVersion, out var ver) && ver >= VersionMineHit)
             {
                 return CryptoHelper.StringToMd5($"{ReplayVersion}-{TimePlayed}-{MapMd5}-{PlayerName}-{(int)Mode}-" +
                                                 $"{(int)Mods}-{Score}-{Accuracy}-{MaxCombo}-{CountMarv}-{CountPerf}-" +

--- a/Quaver.Tools/Commands/RecalculateCommand.cs
+++ b/Quaver.Tools/Commands/RecalculateCommand.cs
@@ -55,8 +55,7 @@ namespace Quaver.Tools.Commands
                 var qua = new Qua();
 
                 var totalObjects = (int)score["count_marv"] + (int)score["count_perf"] + (int)score["count_great"] +
-                                   (int)score["count_good"] + (int)score["count_okay"] + (int)score["count_miss"] +
-                                   (int)score["count_minehit"];
+                                   (int)score["count_good"] + (int)score["count_okay"] + (int)score["count_miss"];
 
                 for (var i = 0; i < totalObjects; i++)
                     qua.HitObjects.Add(new HitObjectInfo());
@@ -80,9 +79,6 @@ namespace Quaver.Tools.Commands
 
                 for (var i = 0; i < (int)score["count_miss"]; i++)
                     processor.CalculateScore(Judgement.Miss, false, false);
-
-                for (var i = 0; i < (int)score["count_minehit"]; i++)
-                    processor.CalculateScore(Judgement.Miss, false, true);
 
                 var difficultyRating = (double)score["performance_rating"] / Math.Pow((double)score["accuracy"] / 98, 6);
 

--- a/Quaver.Tools/Commands/RecalculateCommand.cs
+++ b/Quaver.Tools/Commands/RecalculateCommand.cs
@@ -55,7 +55,8 @@ namespace Quaver.Tools.Commands
                 var qua = new Qua();
 
                 var totalObjects = (int)score["count_marv"] + (int)score["count_perf"] + (int)score["count_great"] +
-                                   (int)score["count_good"] + (int)score["count_okay"] + (int)score["count_miss"];
+                                   (int)score["count_good"] + (int)score["count_okay"] + (int)score["count_miss"] +
+                                   (int)score["count_minehit"];
 
                 for (var i = 0; i < totalObjects; i++)
                     qua.HitObjects.Add(new HitObjectInfo());
@@ -79,6 +80,9 @@ namespace Quaver.Tools.Commands
 
                 for (var i = 0; i < (int)score["count_miss"]; i++)
                     processor.CalculateScore(Judgement.Miss, false, false);
+
+                for (var i = 0; i < (int)score["count_minehit"]; i++)
+                    processor.CalculateScore(Judgement.Miss, false, true);
 
                 var difficultyRating = (double)score["performance_rating"] / Math.Pow((double)score["accuracy"] / 98, 6);
 

--- a/Quaver.Tools/Commands/ReplayBuildCommand.cs
+++ b/Quaver.Tools/Commands/ReplayBuildCommand.cs
@@ -26,7 +26,7 @@ namespace Quaver.Tools.Commands
 
         /// <summary>
         /// <replay_path> <output_path> <quaver_version> <map_md5> <timestamp> <mode> <mods> <score>
-        /// <accuracy> <max_combo> <count_marv> <count_perf> <count_great> <count_good> <count_okay> <count_miss> <pause_count> <username>
+        /// <accuracy> <max_combo> <count_marv> <count_perf> <count_great> <count_good> <count_okay> <count_miss> <count_mine_hit> <pause_count> <username>
         /// </summary>
         /// <param name="args"></param>
         public ReplayBuildCommand(string[] args) : base(args)
@@ -52,7 +52,8 @@ namespace Quaver.Tools.Commands
                 CountGood = int.Parse(args[14]),
                 CountOkay = int.Parse(args[15]),
                 CountMiss = int.Parse(args[16]),
-                PauseCount = int.Parse(args[17])
+                CountMineHit = int.Parse(args[17]),
+                PauseCount = int.Parse(args[18])
             };
 
             OutputPath = args[2];

--- a/Quaver.Tools/Commands/ReplayCommand.cs
+++ b/Quaver.Tools/Commands/ReplayCommand.cs
@@ -46,6 +46,7 @@ namespace Quaver.Tools.Commands
             Replay.CountGood,
             Replay.CountOkay,
             Replay.CountMiss,
+            Replay.CountMineHit,
             Replay.PauseCount,
             Replay.HasData,
             Replay.Frames.Count

--- a/Quaver.Tools/Commands/VirtualReplayPlayerCommand.cs
+++ b/Quaver.Tools/Commands/VirtualReplayPlayerCommand.cs
@@ -121,7 +121,8 @@ namespace Quaver.Tools.Commands
                     Replay.CountGreat,
                     Replay.CountGood,
                     Replay.CountOkay,
-                    Replay.CountMiss
+                    Replay.CountMiss,
+                    Replay.CountMineHit
                 },
                 VirtualReplayPlayer = new
                 {
@@ -134,6 +135,7 @@ namespace Quaver.Tools.Commands
                     CountGood = virtualPlayer.ScoreProcessor.CurrentJudgements[Judgement.Good],
                     CountOkay = virtualPlayer.ScoreProcessor.CurrentJudgements[Judgement.Okay],
                     CountMiss = virtualPlayer.ScoreProcessor.CurrentJudgements[Judgement.Miss],
+                    virtualPlayer.ScoreProcessor.CountMineHit,
                     Hits = hits
                 },
             }));

--- a/Quaver.Tools/Program.cs
+++ b/Quaver.Tools/Program.cs
@@ -23,7 +23,7 @@ namespace Quaver.Tools
                                   $"-calcfolder <folder_path> <mods> `Calculate the difficulty of an entire folder`\n" +
                                   $"-replay <file_path.qr> (-headerless) `Read a replay file and retrieve information about it.`\n" +
                                   $"-virtualreplay <a.qr> <b.qua> <mods (int)> <-hl (optional to read headerless)> `Simulate a replay and retrieve its score outcome.`\n" +
-                                  $"-buildreplay <replay_path> <output_path> <quaver_version> <map_md5> <timestamp> <mode> <mods> <score> <accuracy> <max_combo> <count_marv> <count_perf> <count_great> <count_good> <count_okay> <count_miss> <pause_count> <username>\n" +
+                                  $"-buildreplay <replay_path> <output_path> <quaver_version> <map_md5> <timestamp> <mode> <mods> <score> <accuracy> <max_combo> <count_marv> <count_perf> <count_great> <count_good> <count_okay> <count_miss> <count_minehit> <pause_count> <username>\n" +
                                   $"-calcrating <difficulty_rating> <accuracy>\n" +
                                   $"-convertosu <file_path.osu> <output.qua>\n" +
                                   $"-convertsm <file_path.sm> <output directory>\n" +


### PR DESCRIPTION
Replay had a very weird serialization logic about mods, which is 4 bytes on non x.x5 speed mods and 8 bytes on otherwise. This is completely unneeded now and would break new replays from serializing properly.

Add a count_minehit parameter to tools commands